### PR TITLE
Set game numbers to monospace for 10x10

### DIFF
--- a/Modules/psson-BGGAPI/psson-BGGAPI.psm1
+++ b/Modules/psson-BGGAPI/psson-BGGAPI.psm1
@@ -134,7 +134,7 @@ function Get-BGGChallengePlaysForGame {
     [xml]$xmlPlays = Invoke-WebRequest -Uri $playsUri
     $numPlays = 0
     $paddedGameNumber = $([string]$gameNumber).PadLeft(2,'0')
-    $row = "$paddedGameNumber. "
+    $row = "[c]$paddedGameNumber. [/c]"
     if ( $reqPlayer -eq '' ) {
         # No required player
         Write-Verbose "No required player"


### PR DESCRIPTION
Added tags to make the game numbers in the output for 10x10 challenges to monotype to make the stars line up properly.