### PR TITLE
Changed Diversity to use year parameter

### DIFF
--- a/Modules/psson-BGGAPI/psson-BGGAPI.psm1
+++ b/Modules/psson-BGGAPI/psson-BGGAPI.psm1
@@ -157,14 +157,17 @@ function Get-BGGDiversityChallengeList {
     param (
         [Parameter()][string]$BGGUser,
         [Parameter()][string]$Goal = 100,
-        [Parameter()][string]$StartDate,
-        [Parameter()][string]$EndDate
+        [Parameter()][string]$Year
     )
 
-    # TODO: Replace StartDate and EndDate parameters with a single year parameter to match 10x10 function
-
     # Construct API URL for games played by user in given year
+
+    # For some reason these dates couldn't be created inline in the url string the same way it's done for the 10x10 challenge
+    $StartDate = "$Year-01-01"
+    $EndDate = "$Year-12-31"
+
     $url = "https://www.boardgamegeek.com/xmlapi2/plays?username=$BGGUser&mindate=$StartDate&maxdate=$EndDate"
+    Write-Debug "Diversity challenge URL: $url"
 
     # Query the API and parse the XML response
     $response = Invoke-RestMethod $url


### PR DESCRIPTION
Changed the function call for Diversity challenge to use a single year instead of explicit start and end dates.
Changed config file accordingly and tested.

For some reason I couldn't creat the mindate and maxdate strings inline when creating the url for the API. This is odd as that is the way I did it for the 10x10 challenge.

In this case it game me plays all the way back to november 2022 despite the url explicitly stating the proper start and end dates.

When copied side by side all the urls are indistinguishable from each other, so should get the same data from BGG. Very odd.

closes #37 