### PR TITLE
Removed wrapper for H-Index

### DIFF
--- a/H-Index-list.ps1
+++ b/H-Index-list.ps1
@@ -1,3 +1,0 @@
-﻿Import-Module psson-BGGAPI -Force
-
-Get-BGGHIndexList -bggUser 'psson73' -target 38 -cutoff 20 | clip


### PR DESCRIPTION
Removed wrapper script for the H-Index function. Hasn't been used since last year